### PR TITLE
fix items STAC datetime (#980)

### DIFF
--- a/pycsw/ogc/api/records.py
+++ b/pycsw/ogc/api/records.py
@@ -1295,6 +1295,13 @@ def record2json(record, url, collection, mode='ogcapi-records'):
         else:
             record_dict['time'] = record.time_begin
 
+    if mode == 'stac-api':
+        if record.time_begin is not None or record.time_end is not None:
+            record_dict['properties']['start_datetime'] = record.begin_time
+            record_dict['properties']['end_datetime'] = record.end_time
+        else:
+            record_dict['properties']['datetime'] = record.time
+
     return record_dict
 
 

--- a/pycsw/stac/api.py
+++ b/pycsw/stac/api.py
@@ -457,8 +457,8 @@ def links2stacassets(collection, record):
     if 'collection' not in record:
         record['collection'] = collection
 
-    links_assets = [i for i in record['links'] if i['rel'] == 'enclosure']
-    links_to_keep = [i for i in record['links'] if i['rel'] != 'enclosure']
+    links_assets = [i for i in record['links'] if i.get('rel', '') == 'enclosure']
+    links_to_keep = [i for i in record['links'] if i.get('rel', '') != 'enclosure']
 
     record['links'] = links_to_keep
 


### PR DESCRIPTION
# Overview
Adds STAC `datetime` or `start_datetime`/`end_datetime` to items responses in STAC mode.
# Related Issue / Discussion
#980
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pycsw/blob/master/CONTRIBUTING.rst#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pycsw. I confirm that my contributions to pycsw will be compatible with the pycsw license guidelines at the time of contribution.
- [x] I have already previously agreed to the pycsw Contributions and Licensing Guidelines
